### PR TITLE
Adding user field in completions

### DIFF
--- a/Sources/OpenAI/Client.swift
+++ b/Sources/OpenAI/Client.swift
@@ -119,6 +119,7 @@ public final class Client {
        - echo: Echo back the prompt in addition to the completion.
        - stop: Up to 4 sequences where the API will stop generating further tokens.
                The returned text will not contain the stop sequence.
+       - user: A unique user identifier sometimes required by OpenAI for production.
        - presencePenalty: Number between 0 and 1 that penalizes new tokens
                           based on whether they appear in the text so far.
                           Increases the model's likelihood to talk about new topics.


### PR DESCRIPTION
OpenAI requested that I include a user field in a recent app pre-launch review. Wanted to add it in here in case other developers are also being requested to include the field. Here's the note provided by the production review team:
<blockquote type="cite"><center>
Please pass a uniqueID for every user w/ each API call (both for Completion & the Content Filter) e.g. user= $uniqueID. This 'user' param can be passed in the request body along with other params such as prompt, max_tokens etc.
</center></blockquote>