### PR TITLE
Document best practices for using available engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A Swift client for the [OpenAI API](https://beta.openai.com/).
 
 ### Base Series
 
-> Our [base GPT-3 models] can understand and generate natural language. 
-> We offer four base models called `davinci`, `curie`, `babbage`, and `ada` 
+> Our [base GPT-3 models] can understand and generate natural language.
+> We offer four base models called `davinci`, `curie`, `babbage`, and `ada`
 > with different levels of power suitable for different tasks.
 
 #### Completions
@@ -28,12 +28,12 @@ let client = Client(apiKey: apiKey)
 
 let prompt = "Once upon a time"
 
-client.completions(engine: .davinci, 
-                   prompt: prompt, 
-                   numberOfTokens: ...5, 
+client.completions(engine: .davinci,
+                   prompt: prompt,
+                   numberOfTokens: ...5,
                    numberOfCompletions: 1) { result in
     guard case .success(let completions) = result else { return }
-    
+
     completions.first?.choices.first?.text // " there was a girl who"
 }
 ```
@@ -54,8 +54,8 @@ let documents: [String] = [
 
 let query = "president"
 
-client.search(engine: .davinci, 
-              documents: documents, 
+client.search(engine: .davinci,
+              documents: documents,
               query: query) { result in
     guard case .success(let searchResults) = result else { return }
     searchResults.max()?.document // 0 (for "White House")
@@ -80,13 +80,13 @@ let examples: [(String, label: String)] = [
 
 let labels = ["Positive", "Negative", "Neutral"]
 
-client.classify(engine: .curie, 
-                query: query, 
-                examples: examples, 
-                labels: labels, 
+client.classify(engine: .curie,
+                query: query,
+                examples: examples,
+                labels: labels,
                 searchEngine: .ada) { result in
     guard case .success(let classification) = result else { return }
-    
+
     classification.label // "Negative"
 }
 ```
@@ -100,7 +100,7 @@ let apiKey: String // required
 let client = Client(apiKey: apiKey)
 
 let documents: [String] = [
-    "Puppy A is happy.", 
+    "Puppy A is happy.",
     "Puppy B is sad."
 ]
 
@@ -113,23 +113,23 @@ let examples: (context: String, [(question: String, answer: String)]) = (
     ]
 )
 
-client.answer(engine: .curie, 
-              question: question, 
-              examples: examples, 
-              documents: documents, 
-              searchEngine: .ada, 
+client.answer(engine: .curie,
+              question: question,
+              examples: examples,
+              documents: documents,
+              searchEngine: .ada,
               stop: ["\n", "<|endoftext|>"]) { result in
     guard case .success(let response) = result else { return }
-    
+
     response.answers.first // "puppy A."
 }
 ```
 
 ### Codex
 
-> The [Codex] models are descendants of our base GPT-3 models 
-> that can understand and generate code. 
-> Their training data contains both natural language and 
+> The [Codex] models are descendants of our base GPT-3 models
+> that can understand and generate code.
+> Their training data contains both natural language and
 > billions of lines of public code from GitHub.
 
 ```swift
@@ -176,11 +176,11 @@ client.completions(engine: "davinci-codex",
 
 ### Instruct Series
 
-> The [Instruct] models share our base GPT-3 models’ ability to 
-> understand and generate natural language, 
-> but they’re better at understanding and following your instructions. 
-> You simply tell the model what you want it to do, 
-> and it will do its best to fulfill your instructions. 
+> The [Instruct] models share our base GPT-3 models’ ability to
+> understand and generate natural language,
+> but they’re better at understanding and following your instructions.
+> You simply tell the model what you want it to do,
+> and it will do its best to fulfill your instructions.
 
 ```swift
 import OpenAI
@@ -211,11 +211,11 @@ client.completions(engine: "davinci-instruct-beta",
 
 ### Content Filter
 
-> The [content filter] aims to detect generated text that could be 
-> sensitive or unsafe coming from the API. 
+> The [content filter] aims to detect generated text that could be
+> sensitive or unsafe coming from the API.
 > It's currently in beta mode and has three ways of classifying text —
-> as safe, sensitive, or unsafe. 
-> The filter will make mistakes and we have currently built it to 
+> as safe, sensitive, or unsafe.
+> The filter will make mistakes and we have currently built it to
 > err on the side of caution, thus, resulting in higher false positives.
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ client.answer(engine: .curie,
 ```swift
 import OpenAI
 
+// `Engine.ID` provides cases for the
+// `ada`, `babbage`, `curie`, and `davinci` engines.
+// You can add convenience APIs for other engines
+// by defining computed type properties in an extension.
+extension Engine.ID {
+    static var davinciCodex: Self = "code-davinci-002"
+}
+
 let apiKey: String // required
 let client = Client(apiKey: apiKey)
 
@@ -150,7 +158,7 @@ let sumOfEvens = evens.reduce(0, +)
 
 """#
 
-client.completions(engine: "davinci-codex",
+client.completions(engine: .davinciCodex,
                    prompt: prompt,
                    sampling: .temperature(0.0),
                    numberOfTokens: ...256,

--- a/Sources/OpenAI/Supporting Types/Engine.swift
+++ b/Sources/OpenAI/Supporting Types/Engine.swift
@@ -16,7 +16,20 @@ import Foundation
  https://beta.openai.com/docs/engines
  */
 public struct Engine: Hashable, Identifiable, Codable {
-    /// A unique identifier for the engine.
+    /**
+     A unique identifier for the engine.
+
+     This enumeration provides cases for the
+     `ada`, `babbage`, `curie`, and `davinci` engines.
+     You can add convenience APIs for other engines
+     by defining computed type properties in an extension.
+
+     ```swift
+     extension Engine.ID {
+       static var babbageSearchQuery: Self = "babbage-search-query"
+     }
+     ```
+    */
     public enum ID: Hashable {
         /**
          Ada is usually the fastest model and can perform tasks like parsing text, address correction

--- a/Tests/OpenAITests/OpenAITests.swift
+++ b/Tests/OpenAITests/OpenAITests.swift
@@ -29,14 +29,18 @@ final class OpenAITests: XCTestCase {
         client.engines { result in
             expectation.fulfill()
 
-            XCTAssertNoThrow {
+            do {
                 let engines = try result.get()
                 try self.add(XCTAttachment(jsonEncoded: engines))
 
                 XCTAssertNotNil(engines.first(where: { $0.id == .ada }))
                 XCTAssertNotNil(engines.first(where: { $0.id == .babbage }))
+                XCTAssertNotNil(engines.first(where: { $0.id == "code-cushman-001" }))
                 XCTAssertNotNil(engines.first(where: { $0.id == .curie }))
                 XCTAssertNotNil(engines.first(where: { $0.id == .davinci }))
+                XCTAssertNil(engines.first(where: { $0.id == "invalid" }))
+            } catch {
+                XCTFail(error.localizedDescription)
             }
         }
 

--- a/Tests/OpenAITests/Supporting Types/MockOpenAIURLProtocol.swift
+++ b/Tests/OpenAITests/Supporting Types/MockOpenAIURLProtocol.swift
@@ -96,9 +96,14 @@ public final class MockOpenAIURLProtocol: URLProtocol {
             case ("GET", "https://api.openai.com/v1/engines/ada"):
                 json = #"""
                     {
-                        "id": "ada",
-                        "owner": "openai",
-                        "ready": true
+                      "object": "engine",
+                      "id": "ada",
+                      "ready": true,
+                      "owner": "openai",
+                      "created": null,
+                      "permissions": null,
+                      "replicas": null,
+                      "max_replicas": null
                     }
 
                 """#

--- a/Tests/OpenAITests/Supporting Types/MockOpenAIURLProtocol.swift
+++ b/Tests/OpenAITests/Supporting Types/MockOpenAIURLProtocol.swift
@@ -35,6 +35,61 @@ public final class MockOpenAIURLProtocol: URLProtocol {
             switch (self.request.httpMethod, self.request.url?.absoluteString) {
             case ("GET", "https://api.openai.com/v1/engines"):
                 json = #"""
+                    {
+                      "object": "list",
+                      "data": [
+                        {
+                          "object": "engine",
+                          "id": "ada",
+                          "ready": true,
+                          "owner": "openai",
+                          "created": null,
+                          "permissions": null,
+                          "replicas": null,
+                          "max_replicas": null
+                        },
+                        {
+                          "object": "engine",
+                          "id": "babbage",
+                          "ready": true,
+                          "owner": "openai",
+                          "created": null,
+                          "permissions": null,
+                          "replicas": null,
+                          "max_replicas": null
+                        },
+                        {
+                          "object": "engine",
+                          "id": "code-cushman-001",
+                          "ready": true,
+                          "owner": "openai",
+                          "created": null,
+                          "permissions": null,
+                          "replicas": null,
+                          "max_replicas": null
+                        },
+                        {
+                          "object": "engine",
+                          "id": "curie",
+                          "ready": true,
+                          "owner": "openai",
+                          "created": null,
+                          "permissions": null,
+                          "replicas": null,
+                          "max_replicas": null
+                        },
+                        {
+                          "object": "engine",
+                          "id": "davinci",
+                          "ready": true,
+                          "owner": "openai",
+                          "created": null,
+                          "permissions": null,
+                          "replicas": null,
+                          "max_replicas": null
+                        }
+                      ]
+                    }
 
                 """#
 


### PR DESCRIPTION
Related to #8 and #9

As discussed in https://github.com/mattt/OpenAI/pull/9#issuecomment-1117913832, there's no way for this library to provide enumeration cases for each of the OpenAI engines available. 

So as an alternative, this PR documents the pattern of extending `Engine.ID` to provide convenience APIs for any engines used in a codebase.

```swift
extension Engine.ID {
  static var babbageSearchQuery: Self = "babbage-search-query"
}
```

This PR also updates the existing `testEngines()` to run against a mocked response, and updates the mocked response of `GET /v1/engines/ada` with new fields.