### PR TITLE
Deprecate engine cases

### DIFF
--- a/OpenAI.playground/Contents.swift
+++ b/OpenAI.playground/Contents.swift
@@ -14,22 +14,26 @@ let client = OpenAI.Client(apiKey: apiKey)
 
 // MARK: -
 
-let prompt = "Once upon a time"
+extension Engine.ID {
+    static var textDavinci002: Self = "text-davinci-002"
+}
 
-client.completions(engine: .davinci,
+let prompt = "Write a tagline for an ice cream shop."
+
+client.completions(engine: .textDavinci002,
                    prompt: prompt,
                    sampling: .temperature(0.7),
                    numberOfTokens: ...64,
-                   numberOfCompletions: 5,
+                   numberOfCompletions: 1,
                    echo: true,
-                   stop: [".", "\n", "<|endoftext|>"],
+                   stop: ["<|endoftext|>"],
                    presencePenalty: 0,
                    frequencyPenalty: 0,
                    bestOf: 1) { result in
     guard case .success(let completions) = result else { fatalError() }
 
     for choice in completions.flatMap(\.choices) {
-        let sentence = "\(choice.text)."
+        let sentence = "\(choice.text)"
         print(sentence)
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import OpenAI
 // You can add convenience APIs for other engines
 // by defining computed type properties in an extension.
 extension Engine.ID {
-    static var textDavinci002: Self = "textDavinci002"
+    static var textDavinci002: Self = "text-davinci-002"
 }
 
 let apiKey: String // required

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ A Swift client for the [OpenAI API](https://beta.openai.com/).
 > You simply tell the model what you want it to do,
 > and it will do its best to fulfill your instructions.
 
+```swift
+import OpenAI
+
 // `Engine.ID` provides cases for the
 // `ada`, `babbage`, `curie`, and `davinci` engines
 // from the Base Series.
@@ -28,9 +31,6 @@ A Swift client for the [OpenAI API](https://beta.openai.com/).
 extension Engine.ID {
     static var textDavinci002: Self = "textDavinci002"
 }
-
-```swift
-import OpenAI
 
 let apiKey: String // required
 let client = Client(apiKey: apiKey)

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ let client = Client(apiKey: apiKey)
 
 let prompt = "I know it's an unpopular political opinion to hold, but I think that..."
 
-client.completions(engine: "content-filter-alpha-c4",
+client.completions(engine: "content-filter-alpha",
                    prompt: "<|endoftext|>\(prompt)\n--\nLabel:",
                    sampling: .temperature(0.0),
                    numberOfTokens: ...1,

--- a/README.md
+++ b/README.md
@@ -12,13 +12,22 @@ A Swift client for the [OpenAI API](https://beta.openai.com/).
 
 ## Example Usage
 
-### Base Series
+#### Completions (Instruct Series)
 
-> Our [base GPT-3 models] can understand and generate natural language.
-> We offer four base models called `davinci`, `curie`, `babbage`, and `ada`
-> with different levels of power suitable for different tasks.
+> The [Instruct] models share our base GPT-3 models’ ability to
+> understand and generate natural language,
+> but they’re better at understanding and following your instructions.
+> You simply tell the model what you want it to do,
+> and it will do its best to fulfill your instructions.
 
-#### Completions
+// `Engine.ID` provides cases for the
+// `ada`, `babbage`, `curie`, and `davinci` engines
+// from the Base Series.
+// You can add convenience APIs for other engines
+// by defining computed type properties in an extension.
+extension Engine.ID {
+    static var textDavinci002: Self = "textDavinci002"
+}
 
 ```swift
 import OpenAI
@@ -26,19 +35,23 @@ import OpenAI
 let apiKey: String // required
 let client = Client(apiKey: apiKey)
 
-let prompt = "Once upon a time"
+let prompt = "Tell me a story."
 
-client.completions(engine: .davinci,
+client.completions(engine: .textDavinci002, //custom Engine.ID from above
                    prompt: prompt,
-                   numberOfTokens: ...5,
+                   numberOfTokens: ...30,
                    numberOfCompletions: 1) { result in
     guard case .success(let completions) = result else { return }
 
-    completions.first?.choices.first?.text // " there was a girl who"
+    completions.first?.choices.first?.text
 }
 ```
 
-#### Searches
+#### Searches (Base Series)
+
+> Our [base GPT-3 models] can understand and generate natural language.
+> We offer four base models called `davinci`, `curie`, `babbage`, and `ada`
+> with different levels of power suitable for different tasks.
 
 ```swift
 import OpenAI
@@ -62,7 +75,7 @@ client.search(engine: .davinci,
 }
 ```
 
-#### Classifications
+#### Classifications (Base Series)
 
 ```swift
 import OpenAI
@@ -91,7 +104,7 @@ client.classify(engine: .curie,
 }
 ```
 
-#### Answers
+#### Answers (Base Series)
 
 ```swift
 import OpenAI
@@ -136,7 +149,8 @@ client.answer(engine: .curie,
 import OpenAI
 
 // `Engine.ID` provides cases for the
-// `ada`, `babbage`, `curie`, and `davinci` engines.
+// `ada`, `babbage`, `curie`, and `davinci` engines
+// from the Base Series.
 // You can add convenience APIs for other engines
 // by defining computed type properties in an extension.
 extension Engine.ID {
@@ -180,41 +194,6 @@ client.completions(engine: .davinciCodex,
 // NSArray *evens = [numbers filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self % 2 == 0"]];
 // NSInteger sumOfEvens = [[evens valueForKeyPath:@"@sum.self"] integerValue];
 // ```
-```
-
-### Instruct Series
-
-> The [Instruct] models share our base GPT-3 models’ ability to
-> understand and generate natural language,
-> but they’re better at understanding and following your instructions.
-> You simply tell the model what you want it to do,
-> and it will do its best to fulfill your instructions.
-
-```swift
-import OpenAI
-
-let apiKey: String // required
-let client = Client(apiKey: apiKey)
-
-let prompt = "Describe the Swift programming language in a few sentences."
-
-client.completions(engine: "davinci-instruct-beta",
-                   prompt: prompt,
-                   sampling: .temperature(0.0),
-                   numberOfTokens: ...100,
-                   numberOfCompletions: 1,
-                   stop: ["\n\n"],
-                   presencePenalty: 0.0,
-                   frequencyPenalty: 0.0,
-                   bestOf: 1) { result in
-    guard case .success(let completions) = result else { fatalError("\(result)") }
-
-    for choice in completions.flatMap(\.choices) {
-        print("\(choice.text)")
-    }
-}
-// Prints the following:
-// "Swift is a general-purpose programming language that was developed by Apple Inc. for iOS and OS X development. Swift is designed to work with Apple's Cocoa and Cocoa Touch frameworks and the large body of existing Objective-C code written for Apple products. Swift is intended to be more resilient to erroneous code (such as buffer overflow errors) and better support concurrency (such as multi-threading) than Objective-C."
 ```
 
 ### Content Filter

--- a/Sources/OpenAI/Supporting Types/Engine.swift
+++ b/Sources/OpenAI/Supporting Types/Engine.swift
@@ -41,6 +41,7 @@ public struct Engine: Hashable, Identifiable, Codable {
          - Note: Any task performed by a faster model like Ada
                  can be performed by a more powerful model like Curie or Davinci
          */
+        @available(*, deprecated, message: "This is an older model of OpenAI's GPT-3, and may be deprecated in a future version of this Swift client.")
         case ada
 
         /**
@@ -50,6 +51,7 @@ public struct Engine: Hashable, Identifiable, Codable {
 
          Good at: Moderate classification, semantic search classification
          */
+        @available(*, deprecated, message: "This is an older model of OpenAI's GPT-3, and may be deprecated in a future version of this Swift client.")
         case babbage
 
         /**
@@ -59,6 +61,7 @@ public struct Engine: Hashable, Identifiable, Codable {
          Curie is also quite good at answering questions
          and performing Q&A and as a general service chatbot.
          */
+        @available(*, deprecated, message: "This is an older model of OpenAI's GPT-3, and may be deprecated in a future version of this Swift client.")
         case curie
 
         /**
@@ -78,6 +81,7 @@ public struct Engine: Hashable, Identifiable, Codable {
 
          Good at: Language translation, complex classification, text sentiment, summarization
          */
+        @available(*, deprecated, message: "This is an older model of OpenAI's GPT-3, and may be deprecated in a future version of this Swift client.")
         case davinci
 
         case other(String)


### PR DESCRIPTION
Made a few changes here. Please let me know if any of these could be reworked.
-Deprecated the enum cases, which produces some warnings in the package. I haven't figured out how to "deprecate in the future."
-After re-reading OpenAI's documentation, it seems like Completion should be used with the newer Instruct Series, and the other methods should be used with the older Base Series. I've streamlined the readme to reflect this.
-I also moved the extension suggestion higher in the readme so it's more noticeable.